### PR TITLE
Fix Portable AR-2 always having BLUFOR Camo

### DIFF
--- a/addons/main/config.cpp
+++ b/addons/main/config.cpp
@@ -3651,7 +3651,7 @@ class CfgVehicles
 			{
 			};
 		};
-		editorPreview="\A3\EditorPreviews_F\Data\CfgVehicles\B_UAV_01_F.jpg";
+		editorPreview="\A3\EditorPreviews_F\Data\CfgVehicles\O_UAV_01_F.jpg";
 		_generalMacro="DRNP_AR2_O";
 		scope=2;
 		scopeCurator=2;
@@ -3665,7 +3665,7 @@ class CfgVehicles
 		accuracy=0.5;
 		hiddenSelectionsTextures[]=
 		{
-			"A3\Drones_F\Air_F_Gamma\UAV_01\Data\UAV_01_CO.paa"
+			"A3\Drones_F\Air_F_Gamma\UAV_01\Data\UAV_01_OPFOR_CO.paa"
 		};
 		textureList[]=
 		{
@@ -3849,7 +3849,7 @@ class CfgVehicles
 			{
 			};
 		};
-		editorPreview="\A3\EditorPreviews_F\Data\CfgVehicles\B_UAV_01_F.jpg";
+		editorPreview="\A3\EditorPreviews_F\Data\CfgVehicles\I_UAV_01_F.jpg";
 		_generalMacro="DRNP_AR2_I";
 		scope=2;
 		scopeCurator=2;
@@ -3863,7 +3863,7 @@ class CfgVehicles
 		accuracy=0.5;
 		hiddenSelectionsTextures[]=
 		{
-			"A3\Drones_F\Air_F_Gamma\UAV_01\Data\UAV_01_CO.paa"
+			"A3\Drones_F\Air_F_Gamma\UAV_01\Data\UAV_01_INDP_CO.paa"
 		};
 		textureList[]=
 		{


### PR DESCRIPTION
Some next additions could be:
- LDF drone variants, though that might be a hassle to script without creating portable drone items for individual factions;
- Civilian and IDAP AL-6 variants;

If you think the current fix is sufficient for a mod update, we can make some additional changes in this PR to update the build's version as well.